### PR TITLE
Add gpio & adc API.

### DIFF
--- a/stm32f0_hal/Cargo.toml
+++ b/stm32f0_hal/Cargo.toml
@@ -17,6 +17,13 @@ version = "0.1.0"
 [badges.travis-ci]
 repository = "pollen/stm32f0"
 
+[dependencies]
+cortex-m-semihosting = "0.2.0"
+
+[dependencies.clippy]
+optional = true
+version = "*"
+
 [dependencies.cortex-m]
 version = "0.3.1"
 
@@ -26,7 +33,3 @@ version = "0.3.6"
 
 [dependencies.stm32f0x2]
 path = "../stm32f0x2"
-
-[dependencies.clippy]
-optional = true
-version = "*"

--- a/stm32f0_hal/examples/adc.rs
+++ b/stm32f0_hal/examples/adc.rs
@@ -16,11 +16,11 @@ use hal::adc;
 fn main() {
     let mut stdout = hio::hstdout().unwrap();
 
+    let p3 = adc::Input::setup(adc::Pin::P3);
     let p4 = adc::Input::setup(adc::Pin::P4);
-    let p5 = adc::Input::setup(adc::Pin::P5);
 
     loop {
-        writeln!(stdout, "{} {}", p4.read(), p5.read());
+        writeln!(stdout, "{} {}", p3.read(), p4.read());
     }
 }
 

--- a/stm32f0_hal/examples/adc.rs
+++ b/stm32f0_hal/examples/adc.rs
@@ -1,0 +1,35 @@
+#![feature(used)]
+#![no_std]
+
+extern crate stm32f0_hal as hal;
+
+extern crate cortex_m_semihosting;
+extern crate cortex_m_rt;
+extern crate cortex_m;
+
+use cortex_m_semihosting::hio;
+use core::fmt::Write;
+use cortex_m::asm;
+
+use hal::adc;
+
+fn main() {
+    let mut stdout = hio::hstdout().unwrap();
+
+    let p4 = adc::Input::setup(adc::Pin::P4);
+    let p5 = adc::Input::setup(adc::Pin::P5);
+
+    loop {
+        writeln!(stdout, "{} {}", p4.read(), p5.read());
+    }
+}
+
+
+// As we are not using interrupts, we just register a dummy catch all handler
+#[link_section = ".vector_table.interrupts"]
+#[used]
+static INTERRUPTS: [extern "C" fn(); 240] = [default_handler; 240];
+
+extern "C" fn default_handler() {
+    asm::bkpt();
+}

--- a/stm32f0_hal/examples/blinky.rs
+++ b/stm32f0_hal/examples/blinky.rs
@@ -9,8 +9,8 @@ extern crate stm32f0_hal;
 use stm32f0_hal::gpio;
 
 fn main() {
-    let button = gpio::Input::setup(gpio::Pin::P8);
-    let mut led = gpio::Output::setup(gpio::Pin::P9);
+    let button = gpio::Input::setup(gpio::Pin::PA1);
+    let mut led = gpio::Output::setup(gpio::Pin::PA5);
 
     loop {
         if button.read() {

--- a/stm32f0_hal/examples/blinky.rs
+++ b/stm32f0_hal/examples/blinky.rs
@@ -8,15 +8,16 @@ use cortex_m::asm;
 extern crate stm32f0_hal;
 use stm32f0_hal::gpio;
 
-const BTN_PIN: gpio::Pin = gpio::Pin::P6;
-const LED_PIN: gpio::Pin = gpio::Pin::P9;
-
 fn main() {
-    gpio::init(&BTN_PIN, &gpio::Mode::Input);
-    gpio::init(&LED_PIN, &gpio::Mode::Output);
+    let button = gpio::Input::setup(gpio::Pin::P8);
+    let mut led = gpio::Output::setup(gpio::Pin::P9);
 
     loop {
-        gpio::write(&LED_PIN, gpio::read(&BTN_PIN));
+        if button.read() {
+            led.high();
+        } else {
+            led.low();
+        }
     }
 }
 

--- a/stm32f0_hal/examples/gpio.rs
+++ b/stm32f0_hal/examples/gpio.rs
@@ -1,0 +1,35 @@
+#![feature(used)]
+#![no_std]
+
+extern crate stm32f0_hal as hal;
+
+extern crate cortex_m_semihosting;
+extern crate cortex_m_rt;
+extern crate cortex_m;
+
+use cortex_m_semihosting::hio;
+use core::fmt::Write;
+use cortex_m::asm;
+
+use hal::gpio;
+
+fn main() {
+    let mut stdout = hio::hstdout().unwrap();
+
+    let p1 = gpio::Input::setup(gpio::Pin::PA1);
+    let p5 = gpio::Input::setup(gpio::Pin::PA5);
+
+    loop {
+        writeln!(stdout, "{} {}", p1.read(), p5.read());
+    }
+}
+
+
+// As we are not using interrupts, we just register a dummy catch all handler
+#[link_section = ".vector_table.interrupts"]
+#[used]
+static INTERRUPTS: [extern "C" fn(); 240] = [default_handler; 240];
+
+extern "C" fn default_handler() {
+    asm::bkpt();
+}

--- a/stm32f0_hal/src/adc.rs
+++ b/stm32f0_hal/src/adc.rs
@@ -18,12 +18,12 @@
 //! ```
 
 use cortex_m;
-use stm32f0x2::{GPIOA, RCC, ADC};
+use stm32f0x2::{GPIOC, RCC, ADC};
 
-/// ADC Pin available on PORT A
+/// ADC Pin available on PORT C
 pub enum Pin {
+    P3,
     P4,
-    P5,
 }
 
 /// Input Mode Pin
@@ -43,8 +43,8 @@ impl Input {
 
             // ADC Channel selection
             match self.pin {
-                Pin::P4 => adc.chselr.write(|w| w.chsel4().set_bit()),
-                Pin::P5 => adc.chselr.write(|w| w.chsel5().set_bit()),
+                Pin::P3 => adc.chselr.write(|w| w.chsel13().set_bit()),
+                Pin::P4 => adc.chselr.write(|w| w.chsel14().set_bit()),
             }
 
             // Active ADC and Start Conversion
@@ -62,18 +62,18 @@ impl Input {
 fn setup_pin(pin: &Pin) {
     cortex_m::interrupt::free(|cs| {
         let rcc = RCC.borrow(cs);
-        let gpioa = GPIOA.borrow(cs);
+        let gpioc = GPIOC.borrow(cs);
         let adc = ADC.borrow(cs);
 
-        // Clock Activation PORTA
+        // Clock Activation PORTC
         rcc.ahbenr.modify(|_, w| w.iopaen().enabled());
         // Clock activation ADC
         rcc.apb2enr.modify(|_, w| w.adcen().enabled());
 
         // PA Analog Input Channel
         match *pin {
-            Pin::P4 => gpioa.moder.modify(|_, w| w.moder4().analog()),
-            Pin::P5 => gpioa.moder.modify(|_, w| w.moder5().analog()),
+            Pin::P3 => gpioc.moder.modify(|_, w| w.moder3().analog()),
+            Pin::P4 => gpioc.moder.modify(|_, w| w.moder4().analog()),
         }
     });
 }

--- a/stm32f0_hal/src/adc.rs
+++ b/stm32f0_hal/src/adc.rs
@@ -1,0 +1,49 @@
+use cortex_m;
+use stm32f0x2::{GPIOA, RCC, ADC};
+
+pub enum Pin {
+    P4,
+    P5,
+}
+
+pub fn init(pin: &Pin) {
+    cortex_m::interrupt::free(|cs| {
+        let rcc = RCC.borrow(cs);
+        let gpioa = GPIOA.borrow(cs);
+        let adc = ADC.borrow(cs);
+
+        // Clock Activation PORTA
+        rcc.ahbenr.modify(|_, w| w.iopaen().enabled());
+        // Clock activation ADC
+        rcc.apb2enr.modify(|_, w| w.adcen().enabled());
+
+        // PA Analog Input Channel
+        match *pin {
+            Pin::P4 => gpioa.moder.modify(|_, w| w.moder4().analog()),
+            Pin::P5 => gpioa.moder.modify(|_, w| w.moder5().analog()),
+        }
+
+        // ADC Channel selection
+        match *pin {
+            Pin::P4 => adc.chselr.modify(|_, w| w.chsel4().set_bit()),
+            Pin::P5 => adc.chselr.modify(|_, w| w.chsel5().set_bit()),
+        }
+    });
+}
+
+pub fn read(pin: &Pin) -> u16 {
+    // TODO: How to choose which PIN to read?
+
+    cortex_m::interrupt::free(|cs| {
+        let adc = ADC.borrow(cs);
+
+        // Active ADC and Start Conversion
+        adc.cr.write(|w| w.aden().set_bit().adstart().set_bit());
+
+        // Wait end of conversation
+        while adc.isr.read().eoc().bit_is_clear() {}
+
+        // Return result
+        adc.dr.read().data().bits()
+    })
+}

--- a/stm32f0_hal/src/adc.rs
+++ b/stm32f0_hal/src/adc.rs
@@ -1,22 +1,43 @@
+//! # ADC module
+//!
+//! This module provides access to the ADC of the stm32f0 board.
+//! You can:
+//!
+//! * configure a PIN in Input
+//! * read the analog value from the PIN
+//!
+//! ## Examples
+//!
+//! ```
+//! extern crate stm32f0_hal;
+//!
+//! use stm32f0_hal::adc;
+//!
+// ! let p = adc::Input::setup(adc::Pin::P4);
+// ! let b = p.read();
+//! ```
+
 use cortex_m;
 use stm32f0x2::{GPIOA, RCC, ADC};
 
+/// ADC Pin available on PORT A
 pub enum Pin {
     P4,
     P5,
 }
 
+/// Input Mode Pin
 pub struct Input {
     pin: Pin,
 }
 impl Input {
+    /// Setup a PIN in Input Mode
     pub fn setup(pin: Pin) -> Input {
         setup_pin(&pin);
         Input { pin }
     }
+    /// Read the analog value of a PIN
     pub fn read(&self) -> u16 {
-        // TODO: How to choose which PIN to read?
-
         cortex_m::interrupt::free(|cs| {
             let adc = ADC.borrow(cs);
 

--- a/stm32f0_hal/src/adc.rs
+++ b/stm32f0_hal/src/adc.rs
@@ -20,6 +20,12 @@ impl Input {
         cortex_m::interrupt::free(|cs| {
             let adc = ADC.borrow(cs);
 
+            // ADC Channel selection
+            match self.pin {
+                Pin::P4 => adc.chselr.write(|w| w.chsel4().set_bit()),
+                Pin::P5 => adc.chselr.write(|w| w.chsel5().set_bit()),
+            }
+
             // Active ADC and Start Conversion
             adc.cr.write(|w| w.aden().set_bit().adstart().set_bit());
 
@@ -32,7 +38,7 @@ impl Input {
     }
 }
 
-pub fn setup_pin(pin: &Pin) {
+fn setup_pin(pin: &Pin) {
     cortex_m::interrupt::free(|cs| {
         let rcc = RCC.borrow(cs);
         let gpioa = GPIOA.borrow(cs);
@@ -47,12 +53,6 @@ pub fn setup_pin(pin: &Pin) {
         match *pin {
             Pin::P4 => gpioa.moder.modify(|_, w| w.moder4().analog()),
             Pin::P5 => gpioa.moder.modify(|_, w| w.moder5().analog()),
-        }
-
-        // ADC Channel selection
-        match *pin {
-            Pin::P4 => adc.chselr.modify(|_, w| w.chsel4().set_bit()),
-            Pin::P5 => adc.chselr.modify(|_, w| w.chsel5().set_bit()),
         }
     });
 }

--- a/stm32f0_hal/src/gpio.rs
+++ b/stm32f0_hal/src/gpio.rs
@@ -13,15 +13,15 @@
 //!
 //! use stm32f0_hal::gpio;
 //!
-//! gpio::init(gpio::Pin::P6, gpio::Mode::Input);
-//! let b = gpio::read(gpio::Pin::P6);
+//! gpio::init(gpio::Pin::P8, gpio::Mode::Input);
+//! let b = gpio::read(gpio::Pin::P8);
 //!
 //! gpio::init(gpio::Pin::P9, gpio::Mode::Output);
 //! gpio::write(gpio::Pin::P9, true);
 //! ```
 
 use cortex_m;
-use stm32f0x2::{RCC, GPIOA, GPIOC};
+use stm32f0x2::{RCC, GPIOA};
 
 pub enum Mode {
     Input = 0b00,
@@ -29,55 +29,46 @@ pub enum Mode {
 }
 
 pub enum Pin {
-    P0,
-    P1,
-    P2,
-    P3,
-    P4,
-    P5,
-    P6,
-    P7,
     P8,
     P9,
     P10,
-    P11,
-    P12,
-    P13,
-    P14,
-    P15,
 }
 
 
 /// Setup a pin in Input or Output Mode.
-pub fn init(_pin: &Pin, _mode: &Mode) {
+pub fn init(pin: &Pin, mode: Mode) {
     cortex_m::interrupt::free(|cs| {
         let rcc = RCC.borrow(cs);
 
         let gpioa = GPIOA.borrow(cs);
         rcc.ahbenr.modify(|_, w| w.iopaen().enabled());
-        gpioa.moder.modify(|_, w| w.moder0().bits(0b00));
 
-        let gpioc = GPIOC.borrow(cs);
-        rcc.ahbenr.modify(|_, w| w.iopcen().enabled());
-        gpioc.moder.modify(|_, w| w.moder6().bits(0b01));
-        gpioc.moder.modify(|_, w| w.moder7().bits(0b01));
-        gpioc.moder.modify(|_, w| w.moder8().bits(0b01));
-        gpioc.moder.modify(|_, w| w.moder9().bits(0b01));
+        let mode = mode as u8;
+
+        match *pin {
+            Pin::P8 => gpioa.moder.modify(|_, w| w.moder8().bits(mode)),
+            Pin::P9 => gpioa.moder.modify(|_, w| w.moder9().bits(mode)),
+            Pin::P10 => gpioa.moder.modify(|_, w| w.moder10().bits(mode)),
+        }
     });
 }
 
 /// Read a pin in Input Mode.
-pub fn read(_pin: &Pin) -> bool {
-    PA0.read()
+pub fn read(pin: &Pin) -> bool {
+    match *pin {
+        Pin::P8 => PA8.read(),
+        Pin::P9 => PA9.read(),
+        Pin::P10 => PA10.read(),
+    }
 }
 
 /// Write a bool to a pin in Output Mode.
-pub fn write(_pin: &Pin, on: bool) {
-    if on {
-        PC6.high();
-    } else {
-        PC6.low();
-    }
+pub fn write(_pin: &Pin, _on: bool) {
+    // if on {
+    //     PC6.high();
+    // } else {
+    //     PC6.low();
+    // }
 }
 
 
@@ -96,35 +87,31 @@ macro_rules! pin_read {
 }
 
 
-macro_rules! pin {
-    ($PBX:ident, $bsX:ident, $brX:ident) => {
-        /// Digital output
-        pub struct $PBX;
+// macro_rules! pin_write {
+//     ($PBX:ident, $bsX:ident, $brX:ident) => {
+//         /// Digital output
+//         pub struct $PBX;
+//
+//         impl $PBX {
+//             /// Sets the pin "high" (3V3)
+//             pub fn high(&self) {
+//                 // NOTE(safe) atomic write
+//                 unsafe {
+//                     (*GPIOC.get()).bsrr.write(|w| w.$bsX().bit(true));
+//                 }
+//             }
+//
+//             /// Sets the pin "low" (0V)
+//             pub fn low(&self) {
+//                 // NOTE(safe) atomic write
+//                 unsafe {
+//                     (*GPIOC.get()).bsrr.write(|w| w.$brX().bit(true));
+//                 }
+//             }
+//         }
+//     }
+// }
 
-        impl $PBX {
-            /// Sets the pin "high" (3V3)
-            pub fn high(&self) {
-                // NOTE(safe) atomic write
-                unsafe {
-                    (*GPIOC.get()).bsrr.write(|w| w.$bsX().bit(true));
-                }
-            }
-
-            /// Sets the pin "low" (0V)
-            pub fn low(&self) {
-                // NOTE(safe) atomic write
-                unsafe {
-                    (*GPIOC.get()).bsrr.write(|w| w.$brX().bit(true));
-                }
-            }
-        }
-    }
-}
-
-
-pin_read!(PA0, idr0);
-
-pin!(PC6, bs6, br6);
-pin!(PC7, bs7, br7);
-pin!(PC8, bs8, br8);
-pin!(PC9, bs9, br9);
+pin_read!(PA8, idr8);
+pin_read!(PA9, idr9);
+pin_read!(PA10, idr10);

--- a/stm32f0_hal/src/gpio.rs
+++ b/stm32f0_hal/src/gpio.rs
@@ -13,10 +13,10 @@
 //!
 //! use stm32f0_hal::gpio;
 //!
-// ! let p_in = gpio::Input::setup(gpio::Pin::P8);
+// ! let p_in = gpio::Input::setup(gpio::Pin::PA1);
 // ! let b = p_in.read();
 // !
-// ! let p_out = gpio::Output::setup(gpio::Pin::P9);
+// ! let p_out = gpio::Output::setup(gpio::Pin::PA5);
 // ! p_out.write(true);
 //! ```
 
@@ -30,9 +30,8 @@ enum Mode {
 
 /// GPIO Pin available on PORT A
 pub enum Pin {
-    P8,
-    P9,
-    P10,
+    PA1,
+    PA5,
 }
 
 /// Input Mode Pin
@@ -51,9 +50,8 @@ impl Input {
     pub fn read(&self) -> bool {
         unsafe {
             match self.pin {
-                Pin::P8 => (*GPIOA.get()).idr.read().idr8().bit(),
-                Pin::P9 => (*GPIOA.get()).idr.read().idr9().bit(),
-                Pin::P10 => (*GPIOA.get()).idr.read().idr10().bit(),
+                Pin::PA1 => (*GPIOA.get()).idr.read().idr1().bit(),
+                Pin::PA5 => (*GPIOA.get()).idr.read().idr5().bit(),
             }
         }
     }
@@ -81,9 +79,8 @@ impl Output {
     fn set(&mut self, on: bool) {
         unsafe {
             match self.pin {
-                Pin::P8 => (*GPIOA.get()).bsrr.write(|w| w.bs8().bit(on)),
-                Pin::P9 => (*GPIOA.get()).bsrr.write(|w| w.bs9().bit(on)),
-                Pin::P10 => (*GPIOA.get()).bsrr.write(|w| w.bs10().bit(on)),
+                Pin::PA1 => (*GPIOA.get()).bsrr.write(|w| w.bs1().bit(on)),
+                Pin::PA5 => (*GPIOA.get()).bsrr.write(|w| w.bs5().bit(on)),
             }
         }
     }
@@ -100,9 +97,8 @@ fn setup_pin(pin: &Pin, mode: Mode) {
         let mode = mode as u8;
 
         match *pin {
-            Pin::P8 => gpioa.moder.modify(|_, w| w.moder8().bits(mode)),
-            Pin::P9 => gpioa.moder.modify(|_, w| w.moder9().bits(mode)),
-            Pin::P10 => gpioa.moder.modify(|_, w| w.moder10().bits(mode)),
+            Pin::PA1 => gpioa.moder.modify(|_, w| w.moder1().bits(mode)),
+            Pin::PA5 => gpioa.moder.modify(|_, w| w.moder5().bits(mode)),
         }
     });
 }

--- a/stm32f0_hal/src/lib.rs
+++ b/stm32f0_hal/src/lib.rs
@@ -3,6 +3,7 @@
 //! Provides high-level API to the STM32F0 board functionalities. At the moment the following features are available:
 //!
 //! * GPIO
+//! * ADC
 
 #![no_std]
 #![cfg_attr(feature = "clippy", feature(plugin))]
@@ -12,3 +13,4 @@ extern crate cortex_m;
 extern crate stm32f0x2;
 
 pub mod gpio;
+pub mod adc;


### PR DESCRIPTION
Provides a simple API for GPIO and ADC:

## GPIO

* [x] Setup a Input GPIO (with read method)
* [x] Setup a Output GPIO (with write method)

Limitations:
* You can't read the value from an Output Pin at the moment.
* *There is also no check if you defined the PIN as both Input and Output*. 
* Only P8, P9, P10 from the port GPIOA are binded.

## ADC

* [x] Setup a Pin as Input (with read method)

*WIP: The read function is not yet properly setup*.