### PR TITLE
Adc simpler api

### DIFF
--- a/stm32f0_hal/examples/adc.rs
+++ b/stm32f0_hal/examples/adc.rs
@@ -9,8 +9,8 @@ use core::fmt::Write;
 
 fn main() {
     let mut stdout = hio::hstdout().unwrap();
-    let channel0 = adc::Analog::setup(adc::Channel::ADC0);
-    let channel1 = adc::Analog::setup(adc::Channel::ADC1);
+    let channel0 = adc::Analog::setup(adc::Pin::PA0);
+    let channel1 = adc::Analog::setup(adc::Pin::PA1);
     loop {
         writeln!(stdout, "{} {}", channel0.read(), channel1.read()).unwrap();
     }

--- a/stm32f0_hal/examples/servo.rs
+++ b/stm32f0_hal/examples/servo.rs
@@ -3,11 +3,12 @@
 extern crate stm32f0_hal as hal;
 
 use hal::servo;
+use hal::pwm;
 use hal::rcc;
 
 fn main() {
     rcc::init();
-    let servo1 = servo::Servo::init(servo::Pin::PB4);
+    let servo1 = servo::Servo::init(pwm::Pin::PB4);
     servo1.set_position(0.0);
     loop {
         // increase position of 0.5° each 20 ms

--- a/stm32f0_hal/src/adc.rs
+++ b/stm32f0_hal/src/adc.rs
@@ -20,21 +20,21 @@
 use cortex_m;
 use stm32f0x2::{ADC, GPIOA, GPIOC, RCC};
 
-/// ADC Channel
-pub enum Channel {
-    ADC0,
-    ADC1,
-    ADC13,
-    ADC14,
+/// ADC Pin
+pub enum Pin {
+    PA0,
+    PA1,
+    PC13,
+    PC14,
 }
 
 /// Input Mode Pin
 pub struct Analog {
-    pin: Channel,
+    pin: Pin,
 }
 impl Analog {
     /// Setup a PIN in Input Mode
-    pub fn setup(pin: Channel) -> Analog {
+    pub fn setup(pin: Pin) -> Analog {
         setup_pin(&pin);
         Analog { pin }
     }
@@ -43,12 +43,12 @@ impl Analog {
         cortex_m::interrupt::free(|cs| {
             let adc = ADC.borrow(cs);
 
-            // ADC Channel selection
+            // ADC Pin selection
             match self.pin {
-                Channel::ADC0 => adc.chselr.write(|w| w.chsel0().set_bit()),
-                Channel::ADC1 => adc.chselr.write(|w| w.chsel1().set_bit()),
-                Channel::ADC13 => adc.chselr.write(|w| w.chsel13().set_bit()),
-                Channel::ADC14 => adc.chselr.write(|w| w.chsel14().set_bit()),
+                Pin::PA0 => adc.chselr.write(|w| w.chsel0().set_bit()),
+                Pin::PA1 => adc.chselr.write(|w| w.chsel1().set_bit()),
+                Pin::PC13 => adc.chselr.write(|w| w.chsel13().set_bit()),
+                Pin::PC14 => adc.chselr.write(|w| w.chsel14().set_bit()),
             }
 
             // Active ADC and Start Conversion
@@ -63,28 +63,28 @@ impl Analog {
     }
 }
 
-fn setup_pin(pin: &Channel) {
+fn setup_pin(pin: &Pin) {
     cortex_m::interrupt::free(|cs| {
         let rcc = RCC.borrow(cs);
-        let gpioc = GPIOC.borrow(cs);
         let gpioa = GPIOA.borrow(cs);
+        let gpioc = GPIOC.borrow(cs);
         // Clock Activation
         match *pin {
-            Channel::ADC0 => rcc.ahbenr.modify(|_, w| w.iopaen().enabled()),
-            Channel::ADC1 => rcc.ahbenr.modify(|_, w| w.iopaen().enabled()),
-            Channel::ADC13 => rcc.ahbenr.modify(|_, w| w.iopcen().enabled()),
-            Channel::ADC14 => rcc.ahbenr.modify(|_, w| w.iopcen().enabled()),
+            Pin::PA0 => rcc.ahbenr.modify(|_, w| w.iopaen().enabled()),
+            Pin::PA1 => rcc.ahbenr.modify(|_, w| w.iopaen().enabled()),
+            Pin::PC13 => rcc.ahbenr.modify(|_, w| w.iopcen().enabled()),
+            Pin::PC14 => rcc.ahbenr.modify(|_, w| w.iopcen().enabled()),
         }
 
         // Clock activation ADC
         rcc.apb2enr.modify(|_, w| w.adcen().enabled());
 
-        // PA Analog Input Channel
+        // PA Analog Input Pin
         match *pin {
-            Channel::ADC0 => gpioa.moder.modify(|_, w| w.moder0().analog()),
-            Channel::ADC1 => gpioa.moder.modify(|_, w| w.moder1().analog()),
-            Channel::ADC13 => gpioc.moder.modify(|_, w| w.moder3().analog()),
-            Channel::ADC14 => gpioc.moder.modify(|_, w| w.moder4().analog()),
+            Pin::PA0 => gpioa.moder.modify(|_, w| w.moder0().analog()),
+            Pin::PA1 => gpioa.moder.modify(|_, w| w.moder1().analog()),
+            Pin::PC13 => gpioc.moder.modify(|_, w| w.moder3().analog()),
+            Pin::PC14 => gpioc.moder.modify(|_, w| w.moder4().analog()),
         }
     });
 }

--- a/stm32f0_hal/src/servo.rs
+++ b/stm32f0_hal/src/servo.rs
@@ -1,5 +1,4 @@
 use pwm;
-pub use pwm::Pin;
 
 pub struct Servo {
     servo: pwm::Pwm,


### PR DESCRIPTION
simplified API for ADC
- pin instead of channels
- names of pin matching names on the board
- make clear that servo takes a pwm pin as input