### PR TITLE
Add bash scripts for flashing examples

### DIFF
--- a/stm32f0_hal/scripts/flash.sh
+++ b/stm32f0_hal/scripts/flash.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+EXAMPLE=$1
+
+cargo build --example $EXAMPLE &&
+
+arm-none-eabi-gdb ../target/thumbv6m-none-eabi/debug/examples/$EXAMPLE \
+    -ex "target remote :3333" \
+    -ex "load" \
+    -ex "continue"

--- a/stm32f0_hal/scripts/openocd.sh
+++ b/stm32f0_hal/scripts/openocd.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+openocd \
+    -f interface/stlink-v2.cfg \
+    -f board/stm32f0discovery.cfg


### PR DESCRIPTION
These scripts can be used to upload examples to a board using OpenOCD
and GDB. They work for me, but they're certainly not applicable to all
use cases (for example, on any platform that doesn't have Bash). I
figure it's still nice to have them though, even if to just show a
working configuration that one can apply to their own platform.